### PR TITLE
Fine tuning for the balance script

### DIFF
--- a/service/btrfs-balance
+++ b/service/btrfs-balance
@@ -4,7 +4,7 @@ ROOTDEV=/dev/mmcblk0p28
 
 NEED_BALANCE=0
 # Threshold for percentage of free space allocation to run balance
-BALANCE_THRESHOLD=80
+BALANCE_THRESHOLD=75
 
 check_balance_need()
 {

--- a/service/btrfs-balance
+++ b/service/btrfs-balance
@@ -40,7 +40,10 @@ check_balance_need
 echo $NEED_BALANCE
 
 if test $NEED_BALANCE == 1; then
-	btrfs balance start /
+	# We start from empty block groups and advance to more full ones.
+	for usage in 0 10 20 40 60 80 96; do
+		btrfs balance start -dusage=$usage /
+	done
 fi
 
 kill $PID_KEEPALIVE

--- a/service/btrfs-balance
+++ b/service/btrfs-balance
@@ -9,11 +9,11 @@ BALANCE_THRESHOLD=80
 check_balance_need()
 {
 # Check how near we are for full allocation of free space
-	RAWUSE=`btrfs fi show $ROOTDEV | grep $ROOTDEV | \
+	RAWUSE=`btrfs fi show | grep $ROOTDEV | \
 			awk -F ' ' '{print $6}'| grep -o '[0-9.]'*`
 	echo rawuse $RAWUSE
 
-	MAXUSE=`btrfs fi show $ROOTDEV | grep $ROOTDEV | \
+	MAXUSE=`btrfs fi show | grep $ROOTDEV | \
 			awk -F ' ' '{print $4}'| grep -o '[0-9.]*'`
 	echo maxuse $MAXUSE
 


### PR DESCRIPTION
- Fix awk parsing with new btrfs-progs
- Change threshold for running balance from 80% allocated to 75% allocated
- Do balancing in for mostly empty block groups first to minimize chance of failures
