### PR TITLE
[balance] Improved balancing script. Fixes JB#25816

### DIFF
--- a/service/btrfs-balance
+++ b/service/btrfs-balance
@@ -3,49 +3,154 @@
 ROOTDEV=/dev/mmcblk0p28
 
 NEED_BALANCE=0
+USED=0
+RAWUSE=0
+MAXUSE=0
+FREE_SPACE=0
+
 # Threshold for percentage of free space allocation to run balance
 BALANCE_THRESHOLD=75
+# Threshold of battery charge
+CHARGE_THRESHOLD=25
+# Suspend block limit in case we get killed with -9
+SUSPEND_LIMIT=7200
+
+print_help()
+{
+	printf "  Usage: btrfs-balance [OPTIONS]\n\n"
+	printf "  OPTIONS:\n"
+	printf "      -d <dev>  Specify root device on which to run the balance on.\n"
+	printf "                If omitted, default is /dev/mmcblk0p28\n"
+	printf "      -t <prct> Set allocation threshold percent [0,100] at which to\n"
+	printf "                start balance. If omitted, default is 75 %%\n"
+	printf "      -c <prct> Set battery charge threshold percent [0,100] at which to\n"
+	printf "                allow balance operation. If omitted, default is 25 %%\n"
+	printf "      -f        Print amount of free unallocated space on root device in MiB\n"
+	printf "      -h        Print this help\n"
+}
+
+get_usages()
+{
+	MAXUSE=`btrfs fi show 2>&1 | grep $ROOTDEV | \
+			awk -F ' ' '{print $4}'| grep -o '[0-9.]*'`
+	RAWUSE=`btrfs fi show 2>&1 | grep $ROOTDEV | \
+			awk -F ' ' '{print $6}'| grep -o '[0-9.]'*`
+	FREE_SPACE=`awk -v rawuse=$RAWUSE -v maxuse=$MAXUSE 'BEGIN {printf "%d\n", \
+			1000 * maxuse - 1000 * rawuse}'`
+}
+
+get_used()
+{
+	get_usages
+	USED=`awk -v rawuse=$RAWUSE -v maxuse=$MAXUSE 'BEGIN {printf "%d\n", \
+			rawuse * 100 / maxuse}'`
+}
 
 check_balance_need()
 {
-# Check how near we are for full allocation of free space
-	RAWUSE=`btrfs fi show | grep $ROOTDEV | \
-			awk -F ' ' '{print $6}'| grep -o '[0-9.]'*`
-	echo rawuse $RAWUSE
-
-	MAXUSE=`btrfs fi show | grep $ROOTDEV | \
-			awk -F ' ' '{print $4}'| grep -o '[0-9.]*'`
-	echo maxuse $MAXUSE
-
-	USED=`awk -v rawuse=$RAWUSE -v maxuse=$MAXUSE 'BEGIN {printf "%d\n", \
-			rawuse * 100 / maxuse}'`
-	echo used $USED:
+	get_used
 
 	if test $USED -ge $BALANCE_THRESHOLD; then
+		echo "$USED % of space allocated, threshold is $BALANCE_THRESHOLD %, balancing needed"
 		NEED_BALANCE=1;
 	else
-		NEED_BALANCE=0;
+		echo "No need for balance: $USED % allocated, balance limit $BALANCE_THRESHOLD %"
+		return 0
+	fi
+
+	CHARGE_NOW=`cat /run/state/namespaces/Battery/ChargePercentage`
+	IS_CHARGING=`cat /run/state/namespaces/Battery/IsCharging`
+
+	if test $CHARGE_NOW -lt $CHARGE_THRESHOLD && test $IS_CHARGING -eq 0; then
+		echo "Cannot balance, battery charge is too low. Please, plug in charger" >&2
+		NEED_BALANCE=0
+		return 1
 	fi
 }
 
+report_progress()
+{
+	echo "BALANCE_PROGRESS:$1"
+}
 
-
-keepalive &
+# Keep device out of suspend while we balance
+keepalive $SUSPEND_LIMIT&
 PID_KEEPALIVE=$!
 
-echo $PID_KEEPALIVE
+keepalive_cleanup()
+{
+	kill $PID_KEEPALIVE
+	exit $1
+}
+
+trap -- 'keepalive_cleanup 1' TERM HUP SEGV INT ILL FPE ABRT
+
+while getopts "d:t:c:fh" opt; do
+	case $opt in
+	d)
+		if ! test -e $OPTARG; then
+			echo "Root device \"$OPTARG\" does not exist!" >&2
+			keepalive_cleanup 1
+		fi
+		ROOTDEV=$OPTARG
+	;;
+	t)
+		if test $OPTARG -ge 0 && test $OPTARG -le 100; then
+			BALANCE_THRESHOLD=$OPTARG
+		else
+			echo "Error: -t $OPTARG is out of 0-100 range!"
+			keepalive_cleanup 1
+		fi
+	;;
+	c)
+		if test $OPTARG -ge 0 && test $OPTARG -le 100; then
+			CHARGE_THRESHOLD=$OPTARG
+		else
+			echo "Error: -c $OPTARG is out of 0-100 range!"
+			keepalive_cleanup 1
+		fi
+	;;
+	f)
+		get_usages
+		echo $FREE_SPACE
+		keepalive_cleanup 0
+	;;
+	h)
+		print_help
+		keepalive_cleanup 0
+	;;
+	\?)
+		echo "Invalid option: -$OPTARG" >&2
+		print_help
+		keepalive_cleanup 1
+	;;
+	:)
+		print_help
+		keepalive_cleanup 1
+	;;
+
+	esac
+done
 
 check_balance_need
-
-echo $NEED_BALANCE
+RETVAL=$?
+if test $RETVAL -eq 1; then
+	keepalive_cleanup 1
+fi
 
 if test $NEED_BALANCE == 1; then
 	# We start from empty block groups and advance to more full ones.
-	for usage in 0 10 20 40 60 80 96; do
-		btrfs balance start -dusage=$usage /
+	echo "Starting btrfs balance, please leave device idle during balance"
+	for usage in 0 10 20 35 50 75 96; do
+		report_progress $usage
+		if ! btrfs balance start -dusage=$usage /; then
+			echo "Btrfs balance failed while freeing $usage % full block groups"
+			keepalive_cleanup 28 #ENOSPC
+		fi
 	done
 fi
 
-kill $PID_KEEPALIVE
+report_progress 100
 
-exit 0
+echo "Btrfs balance finished"
+keepalive_cleanup 0


### PR DESCRIPTION
Robustness improvements & clean up:
- Better error handling
- limited keepalive with timeout to 2 hours in case of kill -9
- trap signals to clean up keepalive
- unified exit cleanup
- charger / charge detection
- Removed debug printing
- Silenced errors from btrfs-progs when querying allocation
- Added better prints for logging

New features:
- Battery charge threshold setting
- Allocation threshold setting
- root device setting
- progress reporting to stdout
- Unallocated free space query
- Tool internal help print

Signed-off-by: Kalle Jokiniemi kalle.jokiniemi@jolla.com
