### PR TITLE
[balance] Don't report progress in case no balance is run

### DIFF
--- a/service/btrfs-balance
+++ b/service/btrfs-balance
@@ -148,9 +148,8 @@ if test $NEED_BALANCE == 1; then
 			keepalive_cleanup 28 #ENOSPC
 		fi
 	done
+	report_progress 100
 fi
-
-report_progress 100
 
 echo "Btrfs balance finished"
 keepalive_cleanup 0


### PR DESCRIPTION
The os update does not need to know progress in case
there is no need for balancing. Moved the 100 % progress
print inside the balancing if-branch.

Signed-off-by: Kalle Jokiniemi kalle.jokiniemi@jolla.com
