### PR TITLE
Ioclass and oom

### DIFF
--- a/rpm/btrfs-balancer.spec
+++ b/rpm/btrfs-balancer.spec
@@ -1,6 +1,6 @@
 Name:		btrfs-balancer
 Summary:	Automatic balancing service for btrfs filesystem
-Version:	1.2.0
+Version:	1.2.2
 Release:	1
 Group:		System/Filesystems
 License:	BSD

--- a/rpm/btrfs-balancer.spec
+++ b/rpm/btrfs-balancer.spec
@@ -13,6 +13,7 @@ BuildRequires:  pkgconfig(contextkit-statefs)
 BuildRequires:  pkgconfig(keepalive)
 Requires:       systemd
 Requires:       btrfs-balancer-configs
+Requires:       util-linux
 
 %description
 %{summary}

--- a/service/dbus-org.nemomobile.BtrfsBalancer.service
+++ b/service/dbus-org.nemomobile.BtrfsBalancer.service
@@ -6,3 +6,4 @@ After=local-fs.target
 Type=dbus
 BusName=org.nemomobile.BtrfsBalancer
 ExecStart=/usr/sbin/btrfs-balancer server
+OOMScoreAdjust=-250

--- a/src/btrfs.cpp
+++ b/src/btrfs.cpp
@@ -34,6 +34,9 @@
 
 namespace
 {
+// path of the ionice tool
+const QString IONICE_PATH("/usr/bin/ionice");
+
 // path of the btrfs tool
 const QString BTRFS_PATH("/usr/sbin/btrfs");
 
@@ -165,11 +168,14 @@ void Btrfs::startBalance(int maxUsagePercent)
     }
 
     m_currentProcess = new QProcess;
-    m_currentProcess->setProgram(BTRFS_PATH);
+    m_currentProcess->setProgram(IONICE_PATH);
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     env.insert("LANG", "C");
     m_currentProcess->setProcessEnvironment(env);
     m_currentProcess->setArguments(QStringList()
+                                   << "-c"
+                                   << "3"
+                                   << BTRFS_PATH
                                    << "balance"
                                    << "start"
                                    << QString("-dusage=%1").arg(maxUsagePercent)


### PR DESCRIPTION
Sets the IO class of the btrfs balancing operation to Idle, so that the device remains somewhat usable during heavy rebalancing.

Adjusts the OOM score of the btrfs-balancer service to prevent it from getting killed by the kernel's OOM killer in out-of-memory situations. The service must not be killed during balancing as it holds a CPU keepalive to prevent the device from going into suspend.
