### PR TITLE
Added optional allocation goal parameter to have balancing stop when reached

### DIFF
--- a/src/balancecommand.h
+++ b/src/balancecommand.h
@@ -31,6 +31,9 @@
 #include "command.h"
 #include "batterymonitor.h"
 
+#include <QList>
+#include <QVariant>
+
 class BalanceCommand : public Command
 {
     Q_OBJECT
@@ -44,7 +47,8 @@ public slots:
     virtual void start();
 
 private:
-    void callService(const QString &methodName);
+    void callService(const QString &methodName,
+                     const QList<QVariant> &arguments = QList<QVariant>());
 
 private slots:
     void slotDBusCallSuccess() { /* not of interest */ }

--- a/src/btrfs.cpp
+++ b/src/btrfs.cpp
@@ -275,7 +275,6 @@ void Btrfs::slotBalanceFinished(int exitCode, QProcess::ExitStatus status)
     if (exitCode == 0) {
         m_isBalanced = true;
         requestAllocation();
-        //emit balanceFinished(true);
     } else {
         emit balanceFinished(false, 0, 0);
     }

--- a/src/btrfs.cpp
+++ b/src/btrfs.cpp
@@ -85,6 +85,7 @@ Btrfs::Btrfs(QObject *parent)
     , m_currentProcess(0)
     , m_currentProgress(0)
     , m_isBalancing(false)
+    , m_isBalanced(false)
 {
     loadDeviceConfiguration();
 
@@ -157,13 +158,13 @@ void Btrfs::requestAllocation()
 void Btrfs::startBalance(int maxUsagePercent)
 {
     if (m_currentProcess) {
-        emit balanceFinished(false);
+        emit balanceFinished(false, 0, 0);
         return;
     }
 
     if (!m_deviceConfiguration.contains(CONF_ROOT_MOUNTPOINT)) {
         qCritical() << "Cannot get root path. No mountpoint configured.";
-        emit balanceFinished(false);
+        emit balanceFinished(false, 0, 0);
         return;
     }
 
@@ -202,7 +203,7 @@ int Btrfs::getBalanceProgress()
                          << "status"
                          << m_deviceConfiguration.value(CONF_ROOT_MOUNTPOINT));
     process.start(QProcess::ReadOnly);
-    process.waitForFinished(1000);
+    process.waitForFinished();
 
     // don't care about the exit code... it is not 0 for success
     while (!process.atEnd()) {
@@ -217,13 +218,15 @@ int Btrfs::getBalanceProgress()
         }
     }
     // could not determine progress
+    qWarning() << "Could not read btrfs balancing progress."
+               << "Don't worry, this may happen while btrfs is very busy.";
     return -1;
 }
 
 void Btrfs::slotBalanceProgress()
 {
     int progress = getBalanceProgress();
-    if (progress != m_currentProgress && progress != -1) {
+    if (progress > m_currentProgress && progress != -1) {
         m_currentProgress = progress;
         emit balanceProgress(progress);
     }
@@ -253,7 +256,11 @@ void Btrfs::slotAllocationFinished(int exitCode, QProcess::ExitStatus status)
     m_currentProcess->deleteLater();
     m_currentProcess = 0;
 
-    emit allocationReceived(size, used);
+    if (m_isBalanced) {
+        emit balanceFinished(true, size, used);
+    } else {
+        emit allocationReceived(size, used);
+    }
 }
 
 void Btrfs::slotBalanceFinished(int exitCode, QProcess::ExitStatus status)
@@ -266,8 +273,10 @@ void Btrfs::slotBalanceFinished(int exitCode, QProcess::ExitStatus status)
     m_progressTimer.stop();
 
     if (exitCode == 0) {
-        emit balanceFinished(true);
+        m_isBalanced = true;
+        requestAllocation();
+        //emit balanceFinished(true);
     } else {
-        emit balanceFinished(false);
+        emit balanceFinished(false, 0, 0);
     }
 }

--- a/src/btrfs.h
+++ b/src/btrfs.h
@@ -50,7 +50,7 @@ public:
 signals:
     void allocationReceived(qint64 size, qint64 used);
     void balanceProgress(int percents);
-    void balanceFinished(bool success);
+    void balanceFinished(bool success, qint64 size, qint64 used);
 
 private:
     void loadDeviceConfiguration();
@@ -67,6 +67,7 @@ private:
     QTimer m_progressTimer;
     int m_currentProgress;
     bool m_isBalancing;
+    bool m_isBalanced;
 };
 
 #endif // BTRFS_H

--- a/src/btrfsbalancer.h
+++ b/src/btrfsbalancer.h
@@ -65,7 +65,7 @@ public:
      * Emits finished signal after success or failure.
      * Emits progress signals inbetween.
      */
-    void startBalance();
+    void startBalance(int allocationGoal);
 
 signals:
     void pendingChanged(bool pending);
@@ -82,12 +82,14 @@ private:
 private slots:
     void slotReceivedAllocation(qint64 size, qint64 used);
     void slotBalanceProgress(int percents);
-    void slotBalanceFinished(bool success);
+    void slotBalanceFinished(bool success, qint64 size, qint64 used);
 
 private:
     Status m_currentStatus;
     Btrfs *m_currentBtrfs;
     QList<int> m_usageLevels;
+    // we stop balancing if we reach the allocation percentage goal
+    int m_allocationGoal;
 };
 
 #endif // BTRFSBALANCER_H

--- a/src/dbusconnector.cpp
+++ b/src/dbusconnector.cpp
@@ -87,10 +87,10 @@ void Service::checkAllocation()
     m_balancer->checkAllocation();
 }
 
-void Service::startBalance()
+void Service::startBalance(int allocationGoal)
 {
     if (!isPrivileged()) return;
-    m_balancer->startBalance();
+    m_balancer->startBalance(allocationGoal);
 }
 
 void Service::cancel()

--- a/src/dbusconnector.h
+++ b/src/dbusconnector.h
@@ -46,7 +46,7 @@ public slots:
     Q_NOREPLY void checkStatus();
     Q_NOREPLY void checkLastBalanced();
     Q_NOREPLY void checkAllocation();
-    Q_NOREPLY void startBalance();
+    Q_NOREPLY void startBalance(int allocationGoal = 0);
     Q_NOREPLY void cancel();
 
 signals:

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -52,7 +52,8 @@ Options::Options(const QStringList &arguments)
                                         QString::number(DEFAULT_BATTERY_THRESHOLD));
     parser.addOption(batteryThreshold);
     QCommandLineOption allocationThreshold("a",
-                                           "Required filesystem allocation threshold for balancing (0 - 100).",
+                                           "Required filesystem allocation threshold for balancing (0 - 100). "
+                                           "If given, balancing will stop once the threshold has been reached.",
                                            "allocation threshold",
                                            QString::number(DEFAULT_ALLOCATION_TRESHOLD));
     parser.addOption(allocationThreshold);


### PR DESCRIPTION
Also fixed harmless but frightening QProcess output attempting to kill btrfs (btrfs progress couldn't be read in time, 1 s, under very heavy btrfs load).
