### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/btrfs-balancer.spec
+++ b/rpm/btrfs-balancer.spec
@@ -10,7 +10,7 @@ BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(systemsettings) >= 0.2.25
 BuildRequires:  pkgconfig(keepalive)
-BuildRequires:  systemd
+BuildRequires:  pkgconfig(systemd)
 Requires:       systemd
 Requires:       btrfs-balancer-configs
 Requires:       util-linux


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.