### PR TITLE
scripts/btrfs-balance: Eliminate BASHism

### DIFF
--- a/scripts/btrfs-balance
+++ b/scripts/btrfs-balance
@@ -55,7 +55,7 @@ get_charger_state()
 {
 	local res=$(busctl call com.nokia.mce /com/nokia/mce/request com.nokia.mce.request get_charger_state)
 	# 's "on"' -> 'on'
-	res=${res//\"/}
+	res=$(printf '%s' "$res" | sed 's/"//g')
 	res=${res#s }
 	echo ${res:-unknown}
 }


### PR DESCRIPTION
AFAIK, [the parameter expansion in line 58 of the type "string substitution"](https://github.com/sailfishos/btrfs-balancer/commit/a9841fee4194383364324aebc501b96d94ed3e27#diff-491069f1965ccb0506394dca405aa76384f90d722c1e3dd4e227c28e6b002248R58) (`${parameter/pattern/string}`) is a BASHism and not supported by POSIX sh / classic Bourne Shell, dash and ash (Almquist shell).  At least this is what the corresponding man pages tell.

For more aspects and details, see https://github.com/sailfishos/btrfs-balancer/commit/a9841fee4194383364324aebc501b96d94ed3e27#commitcomment-74846912.